### PR TITLE
Updated individual search include optional "exclude" parameter with supported groupId

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -614,12 +614,13 @@ These services will manage the individual domain.
 
 # Individuals [/individuals]
 
-### Individual Search [GET /individuals{?name}{?per_page}{?page}]
+### Individual Search [GET /individuals{?name}{?exclude}{?per_page}{?page}]
 
 + Parameters
     + name: Last (string)
     + per_page: 10 (number) - The number of results
     + page: 1 (number) - The page number
+    + exclude: [groupIds]=1,2,3 (string)
 
 + Request
     + Headers


### PR DESCRIPTION
Corey/Doug I have added the temporary exclude parameter to accommodate Group Leader app's need to search all individuals where not current in the group.